### PR TITLE
update login method + update checksum parsing

### DIFF
--- a/download_oscar/dod.py
+++ b/download_oscar/dod.py
@@ -196,7 +196,7 @@ def get_unique_file_locations(base_url: str, response_content: bytes) -> List[st
             [
                 "/".join([base_url, link["href"]])
                 for link in soup.find_all("a", href=True)
-                if "txt.gz" in link["href"]
+                if "txt.gz" in link["href"] or "jsonl.gz" in link["href"]
             ]
         )
     )

--- a/download_oscar/dod.py
+++ b/download_oscar/dod.py
@@ -13,34 +13,6 @@ from tqdm import tqdm
 from download_oscar.status import Status
 
 
-def login(user: str, password: str, s: sessions.Session, headers):
-    """Logs in to the base website of the oscar dataset.
-
-    Args:
-        user (str): User name of the account to login to.
-        password (str): Password for the user.
-        s (sessions.Session): The session that should be used to login.
-        headers (): The headers used in requests.
-    """
-
-    login_url = "https://humanid.huma-num.fr/"
-    login_data = {
-        "user": user,
-        "password": password,
-        "timezone": "1",
-        "lmAuth": "1HumanID",
-        "skin": "humanid",
-    }
-    response = s.get(login_url, headers=headers)
-
-    soup = BeautifulSoup(response.content, "html5lib")
-
-    login_data["url"] = (soup.find("input", attrs={"name": "url"})["value"],)
-    login_data["token"] = (soup.find("input", attrs={"name": "token"})["value"],)
-
-    response = s.post(login_url, headers=headers, data=login_data)
-
-
 def get_filename(url: str) -> str:
     """Returns the filename from a link.
 
@@ -162,7 +134,7 @@ def download_checksums(s: sessions.Session, checksum_url: str, headers) -> dict:
         dictionary = {}
         for line in lines:
             (key, val) = line.split()
-            dictionary[key] = val
+            dictionary[val] = key
         return dictionary
 
 
@@ -179,7 +151,7 @@ def download_all(user: str, password: str, base_url: str, out, chunk_size: int =
         "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.41 Safari/537.36"
     }
     with requests.session() as session:
-        login(user, password, session, headers)
+        session.auth = (user, password)
 
         response = session.get(base_url, headers=headers)
 


### PR DESCRIPTION
- Login is not longer done via https://humanid.huma-num.fr but on https://oscar-prive.huma-num.fr. I remove the login function and add authentication on session object via `auth`.
- Key and Val are reversed in the new version of the checksum file. We adapt the code according to this new format.